### PR TITLE
[Confluent][Standard Connectors][CC-35412] BQ Migration Script Improvements

### DIFF
--- a/bigquery-v2-sink/migrate-to-bq-v2-sink.py
+++ b/bigquery-v2-sink/migrate-to-bq-v2-sink.py
@@ -367,6 +367,12 @@ def get_user_inputs(legacy_config):
         print("No topic to table mapping is currently configured.")
     print()
 
+    print("📚 Topic to Table Mapping Documentation:")
+    print("Map of topics to tables. The required format is comma-separated tuples.")
+    print("For example: <topic-1>:<table-1>,<topic-2>:<table-2>,...")
+    print("Also, if the topic-to-table map doesn't contain the topic for a record, the connector creates a table with the same name as the topic name.")
+    print()
+
     print("Options:")
     print("1. Use existing mapping (if configured)")
     print("2. Configure new mapping for testing")
@@ -392,6 +398,20 @@ def get_user_inputs(legacy_config):
             print(f"✅ Using existing topic2table mapping: {existing_topic2table_map}")
         else:
             print("✅ No existing mapping found, will use default table names")
+
+    # Check if auto-create tables is disabled and provide table creation guidance
+    if auto_create_tables == "DISABLED":
+        print("\n" + "="*60)
+        print("🏗️  Table Creation Guidance")
+        print("="*60)
+        print("Auto-create tables is set to DISABLED. You may need to create tables manually.")
+        print()
+        print("If you need to create tables with the same schema as existing tables, use:")
+        print("CREATE TABLE `project-id.dataset-name.new_table_name`")
+        print("LIKE `project-id.dataset-name.source_table_name`;")
+        print()
+        print("Replace with your actual project ID, dataset name, and table names.")
+        print("="*60)
 
     # Get date time formatter preference
     print("\n" + "="*50)
@@ -785,8 +805,8 @@ def main():
             storage_config['commit.interval'] = user_inputs['commit_interval']
 
         # Apply auto-create tables and related configs
+        storage_config['auto.create.tables'] = user_inputs['auto_create_tables']
         if user_inputs['auto_create_tables'] != 'DISABLED':
-            storage_config['auto.create.tables'] = user_inputs['auto_create_tables']
             storage_config['partitioning.type'] = user_inputs['partitioning_type']
             if user_inputs['timestamp_partition_field_name']:
                 storage_config['timestamp.partition.field.name'] = user_inputs['timestamp_partition_field_name']

--- a/bigquery-v2-sink/migrate-to-bq-v2-sink.py
+++ b/bigquery-v2-sink/migrate-to-bq-v2-sink.py
@@ -7,7 +7,7 @@ import getpass
 
 auth_token = None
 last_poll_time = datetime.now()
-SCRAPPED_PASSWORD_STRING = "****************"
+SCRUBBED_PASSWORD_STRING = "****************"
 user_email = None
 user_password = None
 
@@ -112,25 +112,21 @@ def get_credentials_input():
                         retry = input("Try again? (yes/no): ").strip().lower()
                         if retry not in ['yes', 'y']:
                             return get_credentials_secure_input()
-                            break
                 except json.JSONDecodeError as e:
                     print(f"❌ Invalid JSON format in credentials file: {e}")
                     retry = input("Try again? (yes/no): ").strip().lower()
                     if retry not in ['yes', 'y']:
                         return get_credentials_secure_input()
-                        break
                 except Exception as e:
                     print(f"❌ Error reading credentials file: {e}")
                     retry = input("Try again? (yes/no): ").strip().lower()
                     if retry not in ['yes', 'y']:
                         return get_credentials_secure_input()
-                        break
             else:
                 print("❌ File not found. Please provide a valid file path.")
                 retry = input("Try again? (yes/no): ").strip().lower()
                 if retry not in ['yes', 'y']:
                     return get_credentials_secure_input()
-                    break
     elif cred_choice == "3":
         # Option 3: Secure input
         return get_credentials_secure_input()
@@ -873,7 +869,7 @@ def main():
         storage_config = apply_defaults(storage_config, user_inputs)
 
         # Handle keyfile input specially for large JSON content
-        if "keyfile" in storage_config and storage_config["keyfile"] == SCRAPPED_PASSWORD_STRING:
+        if "keyfile" in storage_config and storage_config["keyfile"] == SCRUBBED_PASSWORD_STRING:
             print("\n" + "="*60)
             print("🔑 GCP Service Account Keyfile Input")
             print("="*60)
@@ -926,7 +922,7 @@ def main():
 
         # Prompt user to input values for other fields with "****************"
         for key, value in storage_config.items():
-            if value == SCRAPPED_PASSWORD_STRING and key != "keyfile":  # Skip keyfile as it's handled above
+            if value == SCRUBBED_PASSWORD_STRING and key != "keyfile":  # Skip keyfile as it's handled above
                 while True:
                     user_input = input(f"Please enter the value for {key}: ").strip()
                     if user_input:

--- a/bigquery-v2-sink/migrate-to-bq-v2-sink.py
+++ b/bigquery-v2-sink/migrate-to-bq-v2-sink.py
@@ -350,54 +350,100 @@ def get_user_inputs(legacy_config):
                 else:
                     print("❌ Field name cannot be empty. Please try again.")
 
-    # Get topic2table.map configuration for testing
+    # Get testing configuration for project, dataset, and topic2table mapping
     print("\n" + "="*60)
-    print("🗺️  Topic to Table Mapping Configuration")
+    print("🧪 Testing Configuration")
     print("="*60)
-    print("For testing purposes, you can configure topic2table.map to write to different tables.")
-    print("This allows you to test the migration without affecting your production BigQuery tables.")
+    print("For testing purposes, you can configure project, dataset, and topic2table mapping")
+    print("to write to different BigQuery resources. This allows you to test the migration")
+    print("without affecting your production BigQuery tables.")
     print()
 
-    # Show existing topic2table.map if configured
+    # Show current configurations
+    current_project = legacy_config.get("project", "")
+    current_dataset = legacy_config.get("datasets", "")  # V1 uses "datasets", V2 uses "defaultDataset"
     existing_topic2table_map = legacy_config.get("topic2table.map", "")
-    print(f"Current topic2table.map configuration: {existing_topic2table_map if existing_topic2table_map else '(empty)'}")
-    if existing_topic2table_map:
-        print("This maps your Kafka topics to specific BigQuery tables.")
-    else:
-        print("No topic to table mapping is currently configured.")
+
+    print("Current configurations:")
+    print(f"• Project: {current_project if current_project else '(not configured)'}")
+    print(f"• Dataset: {current_dataset if current_dataset else '(not configured)'}")
+    print(f"• Topic2Table Map: {existing_topic2table_map if existing_topic2table_map else '(not configured)'}")
     print()
 
-    print("📚 Topic to Table Mapping Documentation:")
-    print("Map of topics to tables. The required format is comma-separated tuples.")
-    print("For example: <topic-1>:<table-1>,<topic-2>:<table-2>,...")
-    print("Also, if the topic-to-table map doesn't contain the topic for a record, the connector creates a table with the same name as the topic name.")
-    print()
+    testing_choice = input("Do you want to update project, dataset, or topic2table mapping for testing? (yes/no, default is no): ").strip().lower()
 
-    print("Options:")
-    print("1. Use existing mapping (if configured)")
-    print("2. Configure new mapping for testing")
+    # Initialize with current values
+    project_for_migration = current_project
+    dataset_for_migration = current_dataset
+    topic2table_map = existing_topic2table_map
 
-    topic2table_choice = input("Choose option (1-2, default is 1): ").strip()
+    if testing_choice in ['yes', 'y']:
+        print("\n" + "="*50)
+        print("🔧 Testing Configuration Setup")
+        print("="*50)
 
-    if topic2table_choice == "2":
-        print("\n📝 Topic to Table Mapping Input")
-        print("Enter the mapping in format: topic1:table1,topic2:table2")
-        print("Example: my-topic:my-test-table,another-topic:another-test-table")
-        print("This will redirect data to test tables instead of production tables.")
+        # Project configuration
+        print(f"\n📋 Current project: {current_project if current_project else '(not configured)'}")
+        project_update = input("Do you want to update the project for testing? (yes/no): ").strip().lower()
 
-        while True:
-            topic2table_map = input("Enter topic2table mapping: ").strip()
-            if topic2table_map:
-                print(f"✅ Topic to table mapping set to: {topic2table_map}")
-                break
-            else:
-                print("❌ Mapping cannot be empty. Please try again.")
-    else:
-        topic2table_map = existing_topic2table_map
-        if existing_topic2table_map:
-            print(f"✅ Using existing topic2table mapping: {existing_topic2table_map}")
+        if project_update in ['yes', 'y']:
+            while True:
+                new_project = input("Enter new project ID for testing: ").strip()
+                if new_project:
+                    project_for_migration = new_project
+                    print(f"✅ Project set to: {new_project}")
+                    break
+                else:
+                    print("❌ Project ID cannot be empty. Please try again.")
         else:
-            print("✅ No existing mapping found, will use default table names")
+            print(f"✅ Using existing project: {current_project}")
+
+        # Dataset configuration
+        print(f"\n📋 Current dataset: {current_dataset if current_dataset else '(not configured)'}")
+        dataset_update = input("Do you want to update the dataset for testing? (yes/no): ").strip().lower()
+
+        if dataset_update in ['yes', 'y']:
+            while True:
+                new_dataset = input("Enter new dataset name for testing: ").strip()
+                if new_dataset:
+                    dataset_for_migration = new_dataset
+                    print(f"✅ Dataset set to: {new_dataset}")
+                    break
+                else:
+                    print("❌ Dataset name cannot be empty. Please try again.")
+        else:
+            print(f"✅ Using existing dataset: {current_dataset}")
+
+        # Topic2Table mapping configuration
+        print(f"\n📋 Current topic2table mapping: {existing_topic2table_map if existing_topic2table_map else '(not configured)'}")
+        topic2table_update = input("Do you want to update the topic2table mapping for testing? (yes/no): ").strip().lower()
+
+        if topic2table_update in ['yes', 'y']:
+            print("\n📝 Topic to Table Mapping Input")
+            print("Enter the mapping in format: topic1:table1,topic2:table2")
+            print("Example: my-topic:my-test-table,another-topic:another-test-table")
+            print("This will redirect data to test tables instead of production tables.")
+
+            while True:
+                new_topic2table_map = input("Enter topic2table mapping: ").strip()
+                if new_topic2table_map:
+                    topic2table_map = new_topic2table_map
+                    print(f"✅ Topic to table mapping set to: {new_topic2table_map}")
+                    break
+                else:
+                    print("❌ Mapping cannot be empty. Please try again.")
+        else:
+            print(f"✅ Using existing topic2table mapping: {existing_topic2table_map}")
+
+        print("\n" + "="*50)
+        print("✅ Testing Configuration Summary")
+        print("="*50)
+        print(f"• Project: {project_for_migration}")
+        print(f"• Dataset: {dataset_for_migration}")
+        print(f"• Topic2Table Map: {topic2table_map}")
+        print("="*50)
+    else:
+        print("✅ Using existing configurations for all settings")
 
     # Check if auto-create tables is disabled and provide table creation guidance
     if auto_create_tables == "DISABLED":
@@ -443,6 +489,8 @@ def get_user_inputs(legacy_config):
         'partitioning_type': partitioning_type,
         'timestamp_partition_field_name': timestamp_partition_field_name,
         'topic2table_map': topic2table_map,
+        'project_for_migration': project_for_migration,
+        'dataset_for_migration': dataset_for_migration,
         'use_date_time_formatter': use_date_time_formatter
     }
 
@@ -494,7 +542,7 @@ def transform_legacy_to_storage(legacy_config):
         config_mapping = {
             "topics": "topics",
             "project": "project",
-            "defaultDataset": "defaultDataset",
+            "datasets": "datasets",
             "keyfile": "keyfile",
             "input.data.format": "input.data.format",
             "sanitize.topics": "sanitize.topics",
@@ -814,6 +862,12 @@ def main():
         # Apply topic2table.map configuration
         if user_inputs['topic2table_map']:
             storage_config['topic2table.map'] = user_inputs['topic2table_map']
+
+        # Apply project and dataset configuration
+        if user_inputs['project_for_migration']:
+            storage_config['project'] = user_inputs['project_for_migration']
+        if user_inputs['dataset_for_migration']:
+            storage_config['datasets'] = user_inputs['dataset_for_migration']
 
         # Apply default values from Storage Write API connector template
         storage_config = apply_defaults(storage_config, user_inputs)


### PR DESCRIPTION
## Problem
- The current BigQuery migration tool requires users to provide credentials via environment variables, which is not ideal because they may get stored in terminal history.
- This is continuation PR for https://github.com/confluentinc/confluent-connector-migration-tool/pull/2. We have addressed the fixes based on feedback received from customers and during connect sprint demo session.
- JIRA : https://confluentinc.atlassian.net/browse/CC-35412

## Solution
- Hide credentials when entered through the terminal.
- Allow credentials to be provided via a JSON file.
- Mask the keyfile value when logging the new connector configuration, as it contains secrets.
- Add support for writing to a custom Big query table by allowing configuration of the project, dataset and topic2table map.
- Change the default for auto.create.table to disabled instead of non-partitioned.

## Test Strategy
 ✅ Manual validation has been performed to ensure accurate behavior and data flow continuity for all four supported modes:
  - Streaming
  - Batch Loading
  - Upsert
  - Upsert-Delete

## Release Plan
  - We plan to include a reference to this script in the BigQuery v2 Connector documentation under the “Migrating from v1” section.
  - This tool will assist customers in performing self-service migrations with confidence, following successful internal validation and enablement.