### PR TITLE
[Confluent][Standard Connectors][CC-35712] HTTP Migration Script - Added file and hidden secret support for CC Creds

### DIFF
--- a/http-v2-sink/README.md
+++ b/http-v2-sink/README.md
@@ -9,7 +9,26 @@ This tool migrates HTTP V1 sink connector to the HTTP V2 sink connector in Confl
 
 2. **Fetch the environment name and cluster id** (from your kafka cluster's URL)
 
-3. **Set environment variables EMAIL and PASSWORD** on your terminal. These are the credentials you use to login on Confluent Cloud UI.
+3. **Set Credentials**. The tool supports three methods for providing your Confluent Cloud credentials:
+
+### Option 1: Environment Variables
+```bash
+export EMAIL="your-email@example.com"
+export PASSWORD="your-password"
+```
+⚠️ **Security Note**: Environment variables may be visible in process lists and command history.
+
+### Option 2: Credentials File (RECOMMENDED)
+Create a JSON file with your credentials:
+```json
+{
+  "email": "your-email@example.com",
+  "password": "your-password"
+}
+```
+
+### Option 3: Secure Input
+Enter credentials interactively when prompted. The password will be hidden when typing.
 
 4. **Run the tool** after adding appropriate values:
    ```bash
@@ -17,7 +36,11 @@ This tool migrates HTTP V1 sink connector to the HTTP V2 sink connector in Confl
      --cluster_id "<YOUR_KAFKA_CLUSTER_ID>"
    ```
 
-5. **Follow the interactive prompts**. The tool might ask you for a few secrets which you've had in the V1 connector. It will also ask for confirmation before creating the V2 connector.
+5. **Follow the interactive prompts**. The tool will guide you through:
+   - **Credentials**: Choose secure method for Confluent Cloud authentication
+   - **Connector Status**: Review current V1 connector status and proceed with confirmation
+   - **Configuration Review**: Review the transformed V2 configuration before creation
+   - **Confirmation**: Confirm before creating the V2 connector
 
 ## Important Notes
 
@@ -37,6 +60,16 @@ python3 migrate-to-http-v2-sink.py \
   --v1_connector "my-http-v1-sink" \
   --environment "env-123456" \
   --cluster_id "lkc-abc123"
+```
+
+## Example Credentials File
+
+Create a file named `credentials.json`:
+```json
+{
+  "email": "user@example.com",
+  "password": "your-password"
+}
 ```
 
 ## Related Documentation

--- a/http-v2-sink/migrate-to-http-v2-sink.py
+++ b/http-v2-sink/migrate-to-http-v2-sink.py
@@ -303,7 +303,7 @@ def get_credentials_input():
     print()
     print("SECURITY NOTE: Option 2 (file) is recommended to avoid password exposure in command history.")
 
-    cred_choice = input("Choose option (1-3, default is 2): ").strip()
+    cred_choice = input("Choose option (1-3, default is 1): ").strip()
 
     if cred_choice == "2":
         # Option 2: File (RECOMMENDED)

--- a/http-v2-sink/migrate-to-http-v2-sink.py
+++ b/http-v2-sink/migrate-to-http-v2-sink.py
@@ -325,25 +325,21 @@ def get_credentials_input():
                         retry = input("Try again? (yes/no): ").strip().lower()
                         if retry not in ['yes', 'y']:
                             return get_credentials_secure_input()
-                            break
                 except json.JSONDecodeError as e:
                     print(f"❌ Invalid JSON format in credentials file: {e}")
                     retry = input("Try again? (yes/no): ").strip().lower()
                     if retry not in ['yes', 'y']:
                         return get_credentials_secure_input()
-                        break
                 except Exception as e:
                     print(f"❌ Error reading credentials file: {e}")
                     retry = input("Try again? (yes/no): ").strip().lower()
                     if retry not in ['yes', 'y']:
                         return get_credentials_secure_input()
-                        break
             else:
                 print("❌ File not found. Please provide a valid file path.")
                 retry = input("Try again? (yes/no): ").strip().lower()
                 if retry not in ['yes', 'y']:
                     return get_credentials_secure_input()
-                    break
     elif cred_choice == "3":
         # Option 3: Secure input
         return get_credentials_secure_input()
@@ -410,16 +406,16 @@ def main():
             if user_input.lower() != 'yes':
                 print("Exiting the migration tool...")
                 return
-    
+
         print("Fetching v1 connector offsets...")
         offsets = get_connector_offsets(base_url, env, lkc, connector_name)
-    
+
         print("Fetching V1 connector's config...")
         v1_config = get_connector_config(base_url, env, lkc, connector_name)
-    
+
         print("Transforming V1 connector's config to V2...")
         v2_config = create_v2_config(v1_config)
-    
+
         # Display the V2 configuration and ask for confirmation
         print("\nThe transformed V2 connector configuration is as follows:")
         print(json.dumps(v2_config, indent=4))
@@ -430,7 +426,7 @@ def main():
 
         print("Creating V2 connector with offset set to that of V1 connector...")
         send_create_request(base_url, env, lkc, connector_name, v2_config, offsets)
-    
+
     except APIError as e:
         print(f"Encountered Error: {e}, Status Code: {e.status_code}, Response: {e.response_text}")
     except Exception as e:


### PR DESCRIPTION
## Problem
- The current HTTP migration script only supports providing Confluent Cloud credentials via environment variables, which can lead to security concerns if credentials are exposed in terminal history or logs.
- Customers have requested a safer, more flexible way to pass these credentials during migration.
- JIRA : https://confluentinc.atlassian.net/browse/CC-35712

## Solution
- Support for reading credentials from a hidden secret input in the terminal.
- Support for reading Confluent Cloud credentials from a file (JSON).
- Ensure credentials are masked in logs to prevent accidental exposure.

## Impact
 - It will help customers perform self-service migrations more securely and confidently, following successful internal validation and enablement.

## Test Strategy
 ✅ Manually tested both new input methods (file and hidden secret) to confirm:
  - Credentials are correctly loaded.
  - Secrets are not exposed in logs.
  - Migration flow works as expected with the new options.

## Release Plan.
  - This is a public repository, so this improvement will be publicly available once the changes are merged after reviews.