### PR TITLE
[Confluent][CC-37373] Fixing environment id in readme files

### DIFF
--- a/bigquery-v2-sink/README.md
+++ b/bigquery-v2-sink/README.md
@@ -37,7 +37,7 @@ The tool will show the current status of your BigQuery Legacy sink connector.
 - **For production tables**: It's recommended to pause the V1 connector to avoid data duplication
 
 ### 2. Get Environment Details
-Fetch the environment name and cluster ID from your Kafka cluster's URL in Confluent Cloud.
+Fetch the environment id and cluster ID from your Kafka cluster's URL in Confluent Cloud.
 
 ### 3. Set Credentials
 The tool supports three methods for providing your Confluent Cloud credentials:
@@ -63,7 +63,7 @@ Enter credentials interactively when prompted. The password will be hidden when 
 
 ### 4. Run the Migration Tool
 ```bash
-python3 migrate-to-bq-v2-sink.py --legacy_connector "<YOUR_LEGACY_CONNECTOR_NAME>" --environment "<YOUR_ENVIRONMENT_NAME>" --cluster_id "<YOUR_KAFKA_CLUSTER_ID>"
+python3 migrate-to-bq-v2-sink.py --legacy_connector "<YOUR_LEGACY_CONNECTOR_NAME>" --environment "<YOUR_ENVIRONMENT_ID>" --cluster_id "<YOUR_KAFKA_CLUSTER_ID>"
 ```
 
 ### 5. Follow the Interactive Prompts

--- a/http-v2-sink/README.md
+++ b/http-v2-sink/README.md
@@ -7,7 +7,7 @@ This tool migrates HTTP V1 sink connector to the HTTP V2 sink connector in Confl
 
 1. **Pause the V1 sink connector**. You will get a warning (can proceed after confirmation) while running this tool if the connector is not paused.
 
-2. **Fetch the environment name and cluster id** (from your kafka cluster's URL)
+2. **Fetch the environment id and cluster id** (from your kafka cluster's URL)
 
 3. **Set Credentials**. The tool supports three methods for providing your Confluent Cloud credentials:
 
@@ -32,8 +32,7 @@ Enter credentials interactively when prompted. The password will be hidden when 
 
 4. **Run the tool** after adding appropriate values:
    ```bash
-   python3 migrate-to-http-v2-sink.py --v1_connector "<YOUR_V1_CONNECTOR_NAME>" --environment "<YOUR_ENVIRONMENT_NAME>"
-     --cluster_id "<YOUR_KAFKA_CLUSTER_ID>"
+   python3 migrate-to-http-v2-sink.py --v1_connector "<YOUR_V1_CONNECTOR_NAME>" --environment <YOUR_ENVIRONMENT_ID> --cluster_id "<YOUR_KAFKA_CLUSTER_ID>"
    ```
 
 5. **Follow the interactive prompts**. The tool will guide you through:

--- a/http-v2-sink/README.md
+++ b/http-v2-sink/README.md
@@ -32,7 +32,7 @@ Enter credentials interactively when prompted. The password will be hidden when 
 
 4. **Run the tool** after adding appropriate values:
    ```bash
-   python3 migrate-to-http-v2-sink.py --v1_connector "<YOUR_V1_CONNECTOR_NAME>" --environment <YOUR_ENVIRONMENT_ID> --cluster_id "<YOUR_KAFKA_CLUSTER_ID>"
+   python3 migrate-to-http-v2-sink.py --v1_connector "<YOUR_V1_CONNECTOR_NAME>" --environment "<YOUR_ENVIRONMENT_ID>" --cluster_id "<YOUR_KAFKA_CLUSTER_ID>"
    ```
 
 5. **Follow the interactive prompts**. The tool will guide you through:


### PR DESCRIPTION
# Problem
The README files for the BigQuery V2 and HTTP V2 connector migration subdirectories in the [Confluent Connector Migration Tool repository](https://github.com/confluentinc/confluent-connector-migration-tool) currently reference the environment name in their examples.
This can be misleading for customers, as the migration script actually requires the environment ID (not the name) to run successfully

# Solution
In this PR, I have updated the README documentation for both connectors to explicitly mention environment ID instead of environment name, ensuring the instructions align with the script requirements and reduce confusion for users.